### PR TITLE
Set firebase REST response to silent

### DIFF
--- a/api/plugins/ginfo/ginfo.py
+++ b/api/plugins/ginfo/ginfo.py
@@ -109,7 +109,7 @@ class GinfoPlugin(object):
         }
 
         response = requests.patch(
-            url=self.API_URL + '/.json',
+            url=self.API_URL + '/.json?print=silent',
             json=data
         )
         try:


### PR DESCRIPTION
Adding the `?print=silent` query parameter to the URL can be used to suppress output from the server

https://firebase.google.com/docs/reference/rest/database/#section-param-print

Otherwise, the server will send a response with all data that was sent to the server in the request

https://firebase.google.com/docs/reference/rest/database/#section-patch

Note: if permission is denied, the response still contains the body `"error": "Permission denied"`