### PR TITLE
Fix logic for has_moved

### DIFF
--- a/api/sync/serverdata.py
+++ b/api/sync/serverdata.py
@@ -33,9 +33,9 @@ def sync_characters(server, data):
             character = Character()
 
         has_moved = (
-            (sync_data['x'] == character.x) or
-            (sync_data['y'] == character.y) or
-            (sync_data['z'] == character.y))
+            (sync_data['x'] != character.x) or
+            (sync_data['y'] != character.y) or
+            (sync_data['z'] != character.z))
 
         last_online = (datetime
             .utcfromtimestamp(sync_data['last_online'])


### PR DESCRIPTION
There is a check that determines if a character has moved since the last update. Some actions are only necessary, if the character has moved, e.g. sending an update to Ginfo.

Unfortunately, this check was brocken, and every character had `has_moved=true` all the time. 